### PR TITLE
Minor tweaks to event spec selectors

### DIFF
--- a/cypress/fixtures/event-signup-test-data.json
+++ b/cypress/fixtures/event-signup-test-data.json
@@ -1,8 +1,8 @@
 {
 	"eventsType": "Train to Teach Event",
 	"eventLocation": "Nationwide",
-	"eventsMonth": "October 2020",
-	"eventsNextMonth": "November 2020",
+	"eventsMonth": "November 2020",
+	"eventsNextMonth": "December 2020",
 	"firstName": "Test_user1_first_name",
 	"lastName": "Test_user1_last_name",
 	"email": "testuser@mailsac.com",

--- a/cypress/integration/homepage-smoke.spec.js
+++ b/cypress/integration/homepage-smoke.spec.js
@@ -212,7 +212,7 @@ describe(`Home page tests : Tests execution date and time : ${new Date()}`, () =
 						);
 					});
 			});
-			cy.get('.event-box__header > h2').then((eventDateandTimeonNextPage) => {
+			cy.get('.event-box__header > h4').then((eventDateandTimeonNextPage) => {
 			cy.log(eventDateandTimeonNextPage.text());
 			var a = eventDateandTimeonNextPage.text().split(',');
 			expect(eventDate.trim()).to.equal(a[0].trim());

--- a/cypress/support/pageobjects/EventSignupPage.js
+++ b/cypress/support/pageobjects/EventSignupPage.js
@@ -15,7 +15,7 @@ class EventSignupPage {
 		return cy.get('#events-steps-personal-details-email-field');
 	}
 	getSearchedEventName() {
-		return cy.get('.event-box__header > h2');
+		return cy.get('.event-box__header > h4');
 	}
 	getNextStep() {
 		return cy.contains('Next Step');


### PR DESCRIPTION
The events section recently changed from a `h2` to a `h4` tag for better document structure, this reflects the change in the event specs.

Fast-forward month to November and next month to December (as there are no longer any events in October). We will want a more dynamic way to set these going forward; we could work it out by querying the API or stepping through the months until we hit one with results.