### PR TITLE
Fix selectors for read all stories links

### DIFF
--- a/cypress/integration/homepage-smoke.spec.js
+++ b/cypress/integration/homepage-smoke.spec.js
@@ -125,37 +125,37 @@ describe(`Home page tests : Tests execution date and time : ${new Date()}`, () =
 
 	it('Links through to "career-changers stories"', () => {
 		homePage.getMyStoryInToTeaching().click();
-		cy.get(':nth-child(3) > .content__left > .call-to-action-button').click();
+    cy.contains('a', 'Read all stories about changing career').click();
 		cy.location('pathname').should('equal', Navlinks.careerChangers);
 	});
 
 	it('Links through to "international-career-changers"', () => {
-		homePage.getMyStoryInToTeaching().click();
-		cy.get(':nth-child(6) > .content__left > .call-to-action-button').click();
+    homePage.getMyStoryInToTeaching().click();
+		cy.contains('a', 'Read all stories about international returning teachers').click();
 		cy.location('pathname').should('equal', Navlinks.internationalCareerChangers);
 	});
 
 	it('Links through to "teacher-training-stories"', () => {
 		homePage.getMyStoryInToTeaching().click();
-		cy.get(':nth-child(9) > .content__left > .call-to-action-button').click();
+		cy.contains('a', 'Read all stories about teacher training').click();
 		cy.location('pathname').should('equal', Navlinks.teacherTrainingStories);
 	});
 
 	it('Links through to "making-a-difference"', () => {
 		homePage.getMyStoryInToTeaching().click();
-		cy.get(':nth-child(12) > .content__left > .call-to-action-button').click();
+		cy.contains('a', 'Read all stories about making a difference').click();
 		cy.location('pathname').should('equal', Navlinks.makingADifference);
 	});
 
 	it('Links through to "career-progression"', () => {
 		homePage.getMyStoryInToTeaching().click();
-		cy.get(':nth-child(15) > .content__left > .call-to-action-button').click();
+		cy.contains('a', 'Read all stories about career progression').click();
 		cy.location('pathname').should('equal', Navlinks.careerProgression);
 	});
 
 	it('Links through to "returning to teaching"', () => {
 		homePage.getMyStoryInToTeaching().click();
-		cy.get(':nth-child(18) > .content__left > .call-to-action-button').click();
+		cy.contains('a', 'Read all stories about returning to teaching').click();
 		cy.location('pathname').should('equal', Navlinks.returners);
 	});
 


### PR DESCRIPTION
The selectors were recently changed in a refactoring; instead of using a CSS selector again we now match on the link text, which will be easier to update should they change again in the future.