### PR TITLE
Update Hyperlink

### DIFF
--- a/cypress/integration/regression-tests-suite/homepage.spec.js
+++ b/cypress/integration/regression-tests-suite/homepage.spec.js
@@ -144,7 +144,7 @@ describe(`Home page tests : Tests execution date and time : ${new Date()}`, () =
 	});
 	it('Links through to "Become a teacher in england"', () => {
 		homePage.getWaystoTrainLink().click();
-		cy.contains("a", "Find out more about ways to train").click();
+		cy.contains("a", "get support to improve your subject knowledge").click();
 		cy.location("pathname").should("equal", Navlinks.becomeATeacherInEngland);
 	});
 	it('Links through to "Train to teach events"', () => {


### PR DESCRIPTION
Hyperlink "Find out more about ways to train" has been removed and "get support to improve your subject knowledge" is navigating to "Become a teacher in england" page now.