### PR TITLE
Rename international candidates to student

### DIFF
--- a/cypress/integration/regression-tests-suite/homepage.spec.js
+++ b/cypress/integration/regression-tests-suite/homepage.spec.js
@@ -131,10 +131,10 @@ describe(`Home page tests : Tests execution date and time : ${new Date()}`, () =
 		cy.location("pathname").should("equal", Navlinks.waysToTrain);
 	});
 
-	it('Links through to "International candidates" page', () => {
+	it('Links through to "International student" page', () => {
 		homePage.getFundingyourTrainingLink().click();
-		cy.get("a.button[href='" + Navlinks.internationalCandidates + "']").click();
-		cy.location("pathname").should("equal", Navlinks.internationalCandidates);
+		cy.get("a.button[href='" + Navlinks.internationalStudent + "']").click();
+		cy.location("pathname").should("equal", Navlinks.internationalStudent);
 	});
 
 	it('Links through to "Assessment only providers"', () => {

--- a/cypress/support/pageobjects/Navlinks.js
+++ b/cypress/support/pageobjects/Navlinks.js
@@ -29,7 +29,7 @@ module.exports = class Navlinks {
 		"https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland";
 	static teachingRoleInEngland = "https://teaching-vacancies.service.gov.uk/";
 	static feedback = "https://docs.google.com/forms/d/e/1FAIpQLSdBXbU5nwP6_3TH7HY5rB4ehkSDNzfKqB5X2G7wG4K6LY97-g/viewform";
-	static internationalCandidates = "/international-candidates";
+	static internationalStudent = "/train-to-teach-in-england-as-an-international-student";
 	static exploreOnlineQAs = "/event-categories/online-q-as";
 	static exploreSchoolAndUniversity = "/event-categories/school-and-university-events";
 	static assessmentOnlyProviders = "/assessment-only-providers";


### PR DESCRIPTION
This is required as the original international candidates page has been split into two smaller pages.
