### PR TITLE
Fix failing specs around country dial-in codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 cypress/screenshots/**
 cypress/videos/**
+.DS_Store

--- a/cypress/fixtures/tta-signup-test-data.json
+++ b/cypress/fixtures/tta-signup-test-data.json
@@ -2,7 +2,7 @@
 	"firstName": "User_first_name",
 	"lastName": "User_last_name",
 	"email": "ttauser@mailsac.com",
-	"phoneNumber": "01234567890",
+	"phoneNumber": "441234567890",
 	"previousSubject": "Computing",
 	"day": "25",
 	"month": "05",

--- a/cypress/integration/non-regression-tests-suite/teacher-training-adviser.spec.js
+++ b/cypress/integration/non-regression-tests-suite/teacher-training-adviser.spec.js
@@ -175,7 +175,7 @@ describe("Feature - Get an adviser : Tests execution date and time : " + new Dat
 		cy.enterDateOfBirth("31", "03", "1985");
 		cy.doYouLiveInTheUk(false);
 		cy.whichCountryDoYouLiveIn("Cuba");
-		cy.enterOverseasTelephoneNumber("38484102834");
+		cy.enterOverseasTelephoneNumber("4438484102834");
 		cy.verifyCheckYourAnswersMessage();
 		cy.clickOnContinueButton();
 		cy.acceptPolicy();
@@ -241,7 +241,7 @@ describe("Feature - Get an adviser : Tests execution date and time : " + new Dat
 		cy.enterDateOfBirth("31", "03", "1985");
 		cy.doYouLiveInTheUk(false);
 		cy.whichCountryDoYouLiveIn("Cuba");
-		cy.enterOverseasTelephoneNumber("839494102834");
+		cy.enterOverseasTelephoneNumber("44839494102834");
 		cy.verifyCheckYourAnswersMessage();
 		cy.clickOnContinueButton();
 		cy.acceptPolicy();
@@ -471,7 +471,7 @@ describe("Feature - Get an adviser : Tests execution date and time : " + new Dat
 		cy.enterDateOfBirth("31", "03", "1985");
 		cy.doYouLiveInTheUk(false);
 		cy.whichCountryDoYouLiveIn("Denmark");
-		cy.enterOverseasTelephoneNumber("02637485859");
+		cy.enterOverseasTelephoneNumber("442637485859");
 		cy.verifyCheckYourAnswersMessage();
 		cy.clickOnContinueButton();
 		cy.acceptPolicy();
@@ -1156,7 +1156,7 @@ describe("Feature - Get an adviser : Tests execution date and time : " + new Dat
 		cy.clickOnContinueButton();
 		cy.get("#teacher-training-adviser-steps-overseas-country-country-id-field").select("Austria");
 		cy.clickOnContinueButton();
-		cy.contains("Contact telephone number").type("0125234490");
+		cy.contains("Contact telephone number").type("44125234490");
 		cy.selectTimeZone("(GMT+00:00) Edinburgh");
 		cy.clickOnContinueButton();
 		cy.verifyCheckYourAnswersMessage();
@@ -1203,7 +1203,7 @@ describe("Feature - Get an adviser : Tests execution date and time : " + new Dat
 		cy.enterDateOfBirth("22", "08", "2000");
 		cy.doYouLiveInTheUk(false);
 		cy.whichCountryDoYouLiveIn("Austria");
-		cy.contains("Contact telephone number").type("0125234490");
+		cy.contains("Contact telephone number").type("44125234490");
 		cy.selectTimeZone("(GMT+00:00) Edinburgh");
 		cy.clickOnContinueButton();
 		cy.verifyCheckYourAnswersMessage();
@@ -1240,7 +1240,7 @@ describe("Feature - Get an adviser : Tests execution date and time : " + new Dat
 			.contains(firstName + " " + lastName);
 		cy.contains("Date of birth").next().contains("31 03 1985");
 		cy.contains("Email").next().contains(this.ttaTestData.email);
-		cy.contains("Telephone").next().contains("01234567890");
+		cy.contains("Telephone").next().contains("441234567890");
 		cy.contains("Are you returning to teaching?").next().contains("No");
 		cy.contains("Do you have a degree?").next().contains("Yes");
 		cy.contains("Which subject is your degree?").next().contains("Biology");
@@ -1252,7 +1252,7 @@ describe("Feature - Get an adviser : Tests execution date and time : " + new Dat
 		cy.contains("Where do you live?").next().contains("Overseas");
 		cy.contains("Which country do you live in?").next().contains("Denmark");
 		cy.clickOnBackButton();
-		cy.get("#teacher-training-adviser-steps-overseas-telephone-address-telephone-field").should("have.value", "01234567890");
+		cy.get("#teacher-training-adviser-steps-overseas-telephone-address-telephone-field").should("have.value", "441234567890");
 		cy.wait(100);
 		cy.clickOnBackButton();
 		cy.wait(300);
@@ -1549,7 +1549,7 @@ describe("Feature - Get an adviser : Tests execution date and time : " + new Dat
 		cy.enterDateOfBirth(31, 3, 1985);
 		cy.doYouLiveInTheUk(false);
 		cy.whichCountryDoYouLiveIn("Cyprus");
-		cy.enterOverseasTelephoneNumber("0495");
+		cy.enterOverseasTelephoneNumber("4495");
 		cy.verifyErrorSummaryTitle();
 		cy.get("#teacher-training-adviser-steps-overseas-telephone-address-telephone-error")
 			.should("exist")

--- a/cypress/integration/regression-tests-suite/teacher-training-adviser.spec.js
+++ b/cypress/integration/regression-tests-suite/teacher-training-adviser.spec.js
@@ -108,7 +108,7 @@ describe("Feature - Get an adviser : Tests execution date and time : " + new Dat
 		cy.enterDateOfBirth("31", "03", "1985");
 		cy.doYouLiveInTheUk(true);
 		cy.enterUKCandidateAddress("21", "Victoria Embankment", "Darlington", "DL1 5JR");
-		cy.enterUKTelephoneNumber("0125234490");
+		cy.enterUKTelephoneNumber("44125234490");
 		cy.verifyCheckYourAnswersMessage();
 		cy.clickOnContinueButton();
 		cy.acceptPolicy();

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -223,7 +223,8 @@ Cypress.Commands.add("selectStage", (stage) => {
 });
 
 Cypress.Commands.add("enterOverseasTelephoneNumber", (number) => {
-	cy.get("#teacher-training-adviser-steps-overseas-telephone-address-telephone-field").type(number);
+	// Clear to remove pre-populated country dial-in code
+	cy.get("#teacher-training-adviser-steps-overseas-telephone-address-telephone-field").clear().type(number)
 	cy.clickOnContinueButton();
 });
 


### PR DESCRIPTION
- Add dial-in code to overseas telephone numbers

The dial-in code is now required and the form will fail validation if it is not present.