### PR TITLE
Change 'sign up to mailinglist' to 'find a course'

### DIFF
--- a/cypress/integration/non-regression-tests-suite/homepage.spec.js
+++ b/cypress/integration/non-regression-tests-suite/homepage.spec.js
@@ -103,14 +103,14 @@ describe(`Home page tests : Tests execution date and time : ${new Date()}`, () =
 		cy.location("pathname").should("equal", Navlinks.events);
 	});
 
-	it('Links through to "Sign up for personalised updates"', () => {
-		cy.contains("Sign up for personalised updates")
+	it('Links through to "Find a course"', () => {
+		cy.contains("Find a course")
 			.should((el) => {
-				expect(el).to.have.attr("href", Navlinks.mailingListSignup);
+				expect(el).to.have.attr("href", Navlinks.findACourse);
 			})
 			.click();
 
-		cy.location("pathname").should("equal", Navlinks.mailingListSignup);
+		cy.location("pathname").should("equal", Navlinks.findACourse);
 	});
 
 	/*it("Validate search icon functionality", () => {

--- a/cypress/integration/regression-tests-suite/homepage.spec.js
+++ b/cypress/integration/regression-tests-suite/homepage.spec.js
@@ -72,7 +72,7 @@ describe(`Home page tests : Tests execution date and time : ${new Date()}`, () =
 
 	it('Links through to "Sign up for updates"', () => {
 		homePage.getMailingStripButton().click();
-		cy.location("pathname").should("equal", Navlinks.mailingListSignup);
+		cy.location("pathname").should("equal", Navlinks.findACourse);
 	});
 
 	it('Links through to "My story into teaching"', () => {

--- a/cypress/support/pageobjects/Navlinks.js
+++ b/cypress/support/pageobjects/Navlinks.js
@@ -14,7 +14,7 @@ module.exports = class Navlinks {
 	static careerProgression = "/my-story-into-teaching/career-progression";
 	static returners = "/my-story-into-teaching/returners";
 	static events = "/events";
-	static mailingListSignup = "/mailinglist/signup/name";
+	static findACourse = "/start-teacher-training-this-september";
 	static covid19 = "/covid-19";
 	static facebook = "https://www.facebook.com/getintoteaching";
 	static instagram = "https://www.instagram.com/get_into_teaching/";
@@ -22,7 +22,7 @@ module.exports = class Navlinks {
 		"https://www.linkedin.com/company/9258520?trk=tyah&trkInfo=idx%3A1-1-1%2CtarId%3A1424345327269%2Ctas%3Aget+into+teaching";
 	static twitter = "https://twitter.com/getintoteaching";
 	static youtube = "http://www.youtube.com/user/getintoteaching";
-	static mailingListSignupUrl = "https://get-into-teaching-app-test.london.cloudapps.digital/mailinglist/signup/name";
+	static mailingListSignupUrl = "https://get-into-teaching-app-test.london.cloudapps.digital/start-teacher-training-this-september"
 	static teachInScotland = "https://teachinscotland.scot";
 	static teachInWales = "https://www.discoverteaching.wales/routes-into-teaching/";
 	static teachInNorthernIreland =


### PR DESCRIPTION
The link on the homepage hero has changed from mailing list to a new page about applying this september.