### PR TITLE
Enable test retries

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -22,5 +22,6 @@
 			"html": false,
 			"json": true
 		}
-	}
+	},
+	"retries": 2
 }


### PR DESCRIPTION
Some tests are flaky because of certain unpredictable behaviours. Cypress includes "test retries" for this purpose, when a test fails, it will run again for the specified number of times (I have set it at 2, meaning a test will run for a total of 3 times).