### PR TITLE
Disable event sign up tests

### DIFF
--- a/cypress/integration/non-regression-tests-suite/event-signup-flow.spec.js
+++ b/cypress/integration/non-regression-tests-suite/event-signup-flow.spec.js
@@ -38,7 +38,7 @@ describe("Feature - Event sign up : Tests execution date and time : " + new Date
 		});
 	});
 
-	it("It shows the Sign up complete message - for new candidate who doesn't like to receive email updates", function () {
+	xit("It shows the Sign up complete message - for new candidate who doesn't like to receive email updates", function () {
 		let signedUpeventName;
 		let rnum = Math.floor(Math.random() * 10000000 + 1);
 		firstName = "Testuser_" + rnum + "_firstname";
@@ -73,7 +73,7 @@ describe("Feature - Event sign up : Tests execution date and time : " + new Date
 			}
 		});
 	});
-	it("It shows the Sign up complete message - for existing candidate", function () {
+	xit("It shows the Sign up complete message - for existing candidate", function () {
 		cy.waitForRegistrationToComplete(5000);
 		let signedUpeventName;
 		cy.setEventMonth(this.eventSignupTestData.eventsType, this.eventSignupTestData.eventLocation).then((month) => {
@@ -116,7 +116,7 @@ describe("Feature - Event sign up : Tests execution date and time : " + new Date
 		});
 	});
 
-	it("It shows the Sign up complete message - for new candidate who like to receive email updates", function () {
+	xit("It shows the Sign up complete message - for new candidate who like to receive email updates", function () {
 		// Scenario - candidate who like to receive email updateslike to receive email updates
 		let signedUpeventName;
 		cy.setEventMonth(this.eventSignupTestData.eventsType, this.eventSignupTestData.eventLocation).then((month) => {
@@ -162,7 +162,7 @@ describe("Feature - Event sign up : Tests execution date and time : " + new Date
 		});
 	});
 
-	it('It sends the another email verification code if user clicks on "resend verification" link', function () {
+	xit('It sends the another email verification code if user clicks on "resend verification" link', function () {
 		let signedUpeventName;
 		let rnum = Math.floor(Math.random() * 1000000 + 1);
 		let firstName = "User_" + rnum + "_firstname";

--- a/cypress/integration/regression-tests-suite/event-signup-flow.spec.js
+++ b/cypress/integration/regression-tests-suite/event-signup-flow.spec.js
@@ -21,7 +21,7 @@ describe("Feature - Event sign up : Tests execution date and time : " + new Date
 		cy.verifyPageResponse("/event_categories/online-events/archive");
 	});
 
-	it("It shows the Sign up complete message - for new candidate", function () {
+	xit("It shows the Sign up complete message - for new candidate", function () {
 		let signedUpeventName;
 		let rnum = Math.floor(Math.random() * 10000000 + 1);
 		firstName = "Testuser_" + rnum + "_firstname";


### PR DESCRIPTION
The event sign up tests require Train to Teach events to be present (as they are the only event type that we accept online sign ups for).

Currently there are 0 TTT events live, so the sign ups are all failing.

Disable the tests until we have TTT events live again.