### PR TITLE
Re-introduce teaching event sign up tests

### DIFF
--- a/cypress/fixtures/test_data.json
+++ b/cypress/fixtures/test_data.json
@@ -4,5 +4,8 @@
 	},
 	"getAnAdviser": {
 		"email": "ttauser@mailsac.com"
+	},
+	"events": {
+		"email": "eventsignupuser@mailsac.com"
 	}
 }

--- a/cypress/integration/events.js
+++ b/cypress/integration/events.js
@@ -1,0 +1,141 @@
+describe('Event sign up', () => {
+  var email
+  const eventSelector = '.events-featured__list__item'
+
+  beforeEach(() => {
+    checkEventSelectorIsCorrect()
+    navigateToLastPageOfEvents()
+
+    cy.fixture('test_data.json').then((testData) => {
+      email = testData.events.email
+    })
+  })
+
+  it('Sign up as a new candidate (without mailing list)', () => {    
+    cy.random().then((rand) => {
+      const firstName = `First-${rand}`
+      const lastName = `Last-${rand}`
+
+      cy.anEventExists().then((exists) => {
+        if (exists) {
+          navigateToLastEventSignUp()
+          signUp(firstName, lastName, false)
+        }
+      })
+    })
+  })
+
+  it('Sign up as a new candidate (with mailing list)', () => {    
+    cy.random().then((rand) => {
+      const firstName = `First-${rand}`
+      const lastName = `Last-${rand}`
+
+      cy.anEventExists().then((exists) => {
+        if (exists) {
+          navigateToLastEventSignUp()
+          signUp(firstName, lastName, true)
+        }
+      })
+    })
+  })
+
+  it('Match back an existing candidate (with mailing list, resends verification code)', () => {    
+    cy.random().then((rand) => {
+      const firstName = `First-${rand}`
+      const lastName = `Last-${rand}`
+
+      cy.anEventExists().then((exists) => {
+        if (exists) {
+          navigateToLastEventSignUp()
+          signUp(firstName, lastName, true)
+
+          cy.waitForJobs()
+
+          navigateToLastPageOfEvents()
+          navigateToLastEventSignUp()
+
+          submitPersonalDetails(firstName, lastName)
+
+          cy.clickWithText('resend verification')
+          cy.contains('We\'ve sent you another email.')
+
+          cy.waitForJobs()
+
+          cy.retrieveVerificationCode(email).then((code) => {
+            cy.getByLabel(`Check your email and enter the verification code sent to ${email}`).type(code)
+            cy.clickNext()
+
+            cy.contains('Are you over 16 and do you agree to our privacy policy?')
+            cy.get('.govuk-checkboxes').contains('Yes').click()
+
+            cy.clickCompleteSignUp()
+          })
+        }
+      })
+    })
+  })
+
+  const signUp = (firstName, lastName, mailingList) => {
+    submitPersonalDetails(firstName, lastName)
+
+    cy.getByLabel('Phone number (optional)').type('123456789')
+    cy.clickNext()
+
+    cy.contains('Are you over 16 and do you agree to our privacy policy?')
+    cy.get('.govuk-checkboxes').contains('Yes').click()
+
+    cy.contains('Would you like to receive email updates to help you get into teaching?')
+    cy.get('.govuk-radios__item').contains(mailingList ? 'Yes' : 'No').click()
+
+    if (mailingList) {
+      cy.get('.govuk-radios__item').contains('Yes').click()
+      cy.clickNext()
+      completeMailingListSignUp()
+    } else {
+      cy.get('.govuk-radios__item').contains('No').click()
+    }
+
+    cy.clickCompleteSignUp()
+
+    cy.contains('Sign up complete')
+  }
+
+  const completeMailingListSignUp = () => {
+    cy.getByLabel('Do you have a degree?').select('Final year')
+    cy.getByLabel('How close are you to applying for teacher training?').select('It’s just an idea')
+    cy.getByLabel('What is your postcode? (optional)').type('TE5 1NG')
+    cy.getByLabel('What subject do you want to teach?').select('Maths')
+  }
+
+  const submitPersonalDetails = (firstName, lastName) => {
+    cy.contains('Sign up for this event')
+    cy.getByLabel('First name').type(firstName)
+    cy.getByLabel('Last name').type(lastName)
+    cy.getByLabel('Email address').type(email)
+    cy.clickNext()
+  }
+
+  const navigateToLastPageOfEvents = () => {
+    cy.authVisit('/event-categories/train-to-teach-events')
+
+    cy.get('body').then((body) => {
+      if (body.find('.pagination').length) {
+        cy.get('.pagination .page a').last().click()
+      }
+    })
+  }
+
+  const navigateToLastEventSignUp = () => {
+    cy.get(eventSelector).last().click()
+    cy.clickWithText('Sign up for this event')
+  }
+
+  // The tests are setup to pass when there are no TTT
+  // events. To avoid a false positive we need to verify 
+  // the event selector hasn't changed before each run.
+  const checkEventSelectorIsCorrect = () => {
+    cy.authVisit('/events')
+    cy.acceptCookie()
+    cy.get(eventSelector)
+  }
+})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -48,6 +48,12 @@ Cypress.Commands.add('waitForJobs', () => {
 	cy.wait(8000)
 })
 
+Cypress.Commands.add('anEventExists', () => {
+  cy.get('body').then(body => {
+    cy.wrap(body.find('.events-featured__list__item').length > 0)
+  })
+})
+
 Cypress.Commands.add('retrieveVerificationCode', (email) => {	
 	const apiKey = Cypress.env('MAILING_LIST_USER_EMAIL_API_KEY')
 	cy.request(`https://mailsac.com/api/addresses/${email}/messages?_mailsacKey=${apiKey}`).as('emails')

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -23,5 +23,12 @@ Cypress.on("uncaught:exception", (err, runnable) => {
 
 require("@cypress/skip-test/support");
 
+// Disable Turbolinks
+Cypress.on('window:load', $window => {
+  $window.document.addEventListener('turbolinks:click', event => {
+    event.preventDefault()
+  })
+})
+
 // Alternatively you can use CommonJS syntax:
 // require('./commands')


### PR DESCRIPTION
[Trello-1683](https://trello.com/c/uHWXqJDC/1683-development-re-introduce-event-cypress-tests-when-we-have-ttt-events-again-21-july)

- Disable Turbolinks

Having Turbolinks enabled confuses Cypress as it doesn't wait for AJAX page changes so tries to select an element for the next page before the page has rendered. This is fine most of the time, but if the selector exists on the current page and the next page it will select the element on the current page, the page then changes and then when you try and interact with the selected element (say to click it) you get an error as that element is no longer part of the DOM.

- Add Train to Teach event sign up tests

Add a minimal set of event sign up tests to cover:

```
- Sign up (opt out of mailing list)
- Sign up (opt into mailing list)
- Sign up and then perform a matchback and complete
```

The tests are setup so that if we run into the situation when there are no Train to Teach events on the website the tests will still pass. To avoid false positives we ensure the selector we are using to target an event from the listings is still accurate (i.e. returns non-TTT events at least).