### PR TITLE
Update next step button text

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -29,7 +29,7 @@ Cypress.Commands.add('clickWithText', (text) => {
 })
 
 Cypress.Commands.add('clickNext', () => {
-	cy.clickWithText('Next Step')
+	cy.clickWithText('Next step')
 })
 
 Cypress.Commands.add('clickContinue', () => {


### PR DESCRIPTION
The button text we are using to navigate between steps has changed; this brings it inline so it matches.