### PR TITLE
Support new matchback logic

### DIFF
--- a/cypress/integration/events.js
+++ b/cypress/integration/events.js
@@ -1,57 +1,54 @@
 describe('Event sign up', () => {
-  var email
+  let email
+  let firstName
+  let lastName
   const eventSelector = '.events-featured__list__item'
 
   beforeEach(() => {
     checkEventSelectorIsCorrect()
     navigateToLastPageOfEvents()
-
-    cy.fixture('test_data.json').then((testData) => {
-      email = testData.events.email
+    cy.random().then((rand) => {
+      firstName = `First-${rand}`
+      lastName = `Last-${rand}`
     })
   })
 
-  it('Sign up as a new candidate (without mailing list)', () => {    
-    cy.random().then((rand) => {
-      const firstName = `First-${rand}`
-      const lastName = `Last-${rand}`
+  describe('As a new candidate', () => {
+    before(() => {
+      cy.random().then((rand) => {
+        email = `${rand}@${rand}.never`
+      })
+    })
 
+    it('Signing up (without mailing list)', () => {    
       cy.anEventExists().then((exists) => {
         if (exists) {
           navigateToLastEventSignUp()
           signUp(firstName, lastName, false)
         }
       })
-    })
-  })
 
-  it('Sign up as a new candidate (with mailing list)', () => {    
-    cy.random().then((rand) => {
-      const firstName = `First-${rand}`
-      const lastName = `Last-${rand}`
-
-      cy.anEventExists().then((exists) => {
-        if (exists) {
-          navigateToLastEventSignUp()
-          signUp(firstName, lastName, true)
-        }
+      it('Signing up (with mailing list)', () => {    
+        cy.anEventExists().then((exists) => {
+          if (exists) {
+            navigateToLastEventSignUp()
+            signUp(firstName, lastName, true)
+          }
+        })
       })
     })
   })
 
-  it('Match back an existing candidate (with mailing list, resends verification code)', () => {    
-    cy.random().then((rand) => {
-      const firstName = `First-${rand}`
-      const lastName = `Last-${rand}`
+  describe('As an existing candidate', () => {
+    before(() => {
+      cy.fixture('test_data.json').then((testData) => {
+        email = testData.events.email
+      })
+    })
 
+    it('Signing up (with mailing list, resends verification code)', () => {    
       cy.anEventExists().then((exists) => {
         if (exists) {
-          navigateToLastEventSignUp()
-          signUp(firstName, lastName, true)
-
-          cy.waitForJobs()
-
-          navigateToLastPageOfEvents()
           navigateToLastEventSignUp()
 
           submitPersonalDetails(firstName, lastName)

--- a/cypress/integration/get_an_adviser.js
+++ b/cypress/integration/get_an_adviser.js
@@ -1,37 +1,38 @@
 describe('Mailing list sign up', () => {
-  var email
+  let email
+  let firstName
+  let lastName
 
   beforeEach(() => {
     cy.authVisit(Cypress.env('TTA_ROOT_URL'))
     cy.acceptCookie()
     cy.clickWithText('Start now')
-
-    cy.fixture('test_data.json').then((testData) => {
-      email = testData.getAnAdviser.email
+    cy.random().then((rand) => {
+      firstName = `First-${rand}`
+      lastName = `Last-${rand}`
     })
   })
 
-  it('Sign up as a new candidate', () => {    
-    cy.random().then((rand) => {
-      const firstName = `First-${rand}`
-      const lastName = `Last-${rand}`
+  describe('As a new candidate', () => {
+    before(() => {
+      cy.random().then((rand) => {
+        email = `${rand}@${rand}.never`
+      })
+    })
 
+    it('Signing up', () => {    
       signUp(firstName, lastName)
     })
   })
 
-  it('Match back an existing candidate (resends verification code)', () => {    
-    cy.random().then((rand) => {
-      const firstName = `First-${rand}`
-      const lastName = `Last-${rand}`
+  describe('As an existing candidate', () => {
+    before(() => {
+      cy.fixture('test_data.json').then((testData) => {
+        email = testData.getAnAdviser.email
+      })
+    })
 
-      signUp(firstName, lastName)
-
-      cy.waitForJobs()
-
-      cy.authVisit(Cypress.env('TTA_ROOT_URL'))
-      cy.clickWithText('Start now')
-
+    it('Signing up (resends verification code)', () => {    
       submitPersonalDetails(firstName, lastName)
 
       cy.clickWithText('resend verification')

--- a/cypress/integration/mailing_list.js
+++ b/cypress/integration/mailing_list.js
@@ -3,12 +3,6 @@ describe('Mailing list sign up', () => {
   let firstName
   let lastName
 
-  before(() => {
-    cy.fixture('test_data.json').then((testData) => {
-      email = testData.mailingList.email
-    })
-  })
-
   beforeEach(() => {
     cy.authVisit('/mailinglist/signup')
     cy.acceptCookie()
@@ -19,70 +13,78 @@ describe('Mailing list sign up', () => {
     })
   })
 
-  it('Sign up as a new candidate', () => {
-    signUp(firstName, lastName)
-  })
+  describe('As a new candidate', () => {
+    before(() => {
+      cy.random().then((rand) => {
+        email = `${rand}@${rand}.never`
+      })
+    })
 
-  it('Match back an existing candidate (resends verification code)', () => {
-    signUp(firstName, lastName)
-
-    cy.waitForJobs()
-
-    cy.authVisit('/mailinglist/signup')
-
-    cy.contains('Get personalised guidance to your inbox')
-    submitPersonalDetails(firstName, lastName)
-
-    cy.clickWithText('resend verification')
-    cy.contains("We've sent you another email.")
-
-    cy.waitForJobs()
-
-    cy.retrieveVerificationCode(email).then((code) => {
-      cy.contains('Verify your email address')
-      cy.getByLabel(
-        `Check your email and enter the verification code sent to ${email}`
-      ).type(code)
-      cy.clickNext()
-
-      cy.contains('You’ve already signed up')
+    it('Signing up', () => {
+      signUp(firstName, lastName)
     })
   })
 
-  it('Book a callback on completion of the mailing list sign up', () => {
-    signUp(firstName, lastName)
-
-    cy.waitForJobs()
-
-    cy.contains('Book a callback').click()
-
-    submitPersonalDetails(firstName, lastName)
-    cy.clickNext()
-
-    cy.clickWithText('resend verification')
-    cy.contains("We've sent you another email.")
-
-    cy.waitForJobs()
-
-    cy.retrieveVerificationCode(email).then((code) => {
-      cy.contains('Verify your email address')
-      cy.getByLabel(
-        `Check your email and enter the verification code sent to ${email}`
-      ).type(code)
-      cy.clickNext()
+  describe('As an existing candidate', () => {
+    before(() => {
+      cy.fixture('test_data.json').then((testData) => {
+        email = testData.mailingList.email
+      })
     })
 
-    cy.getByLabel('Phone number').type('1234567890')
-    cy.clickNext()
+    it('Signing up (resends verification code)', () => {  
+      cy.contains('Get personalised guidance to your inbox')
+      submitPersonalDetails(firstName, lastName)
+  
+      cy.clickWithText('resend verification')
+      cy.contains("We've sent you another email.")
+  
+      cy.waitForJobs()
+  
+      cy.retrieveVerificationCode(email).then((code) => {
+        cy.contains('Verify your email address')
+        cy.getByLabel(
+          `Check your email and enter the verification code sent to ${email}`
+        ).type(code)
+        cy.clickNext()
+  
+        cy.contains('You’ve already signed up')
+      })
+    })
 
-    cy.getByLabel('Choose an option').select('Eligibility to become a teacher')
-    cy.clickNext()
-
-    cy.contains('Accept privacy policy')
-    cy.clickWithText('Yes')
-
-    cy.clickWithText('Book your callback')
-    cy.contains('Callback confirmed')
+    it('Booking a callback on completion of the mailing list sign up', () => {
+      cy.authVisit('/mailinglist/signup/completed')
+  
+      cy.contains('Book a callback').click()
+  
+      submitPersonalDetails(firstName, lastName)
+      cy.clickNext()
+  
+      cy.clickWithText('resend verification')
+      cy.contains("We've sent you another email.")
+  
+      cy.waitForJobs()
+  
+      cy.retrieveVerificationCode(email).then((code) => {
+        cy.contains('Verify your email address')
+        cy.getByLabel(
+          `Check your email and enter the verification code sent to ${email}`
+        ).type(code)
+        cy.clickNext()
+      })
+  
+      cy.getByLabel('Phone number').clear().type('1234567890')
+      cy.clickNext()
+  
+      cy.getByLabel('Choose an option').select('Eligibility to become a teacher')
+      cy.clickNext()
+  
+      cy.contains('Accept privacy policy')
+      cy.clickWithText('Yes')
+  
+      cy.clickWithText('Book your callback')
+      cy.contains('Callback confirmed')
+    })
   })
 
   const signUp = (firstName, lastName) => {


### PR DESCRIPTION
Previously the API required the email/first/last to all match an existing candidate, but it will now perform a fallback to just matching on the email address. This means for new sign ups we need to use a unique email address and for matching back we can simplify it by ensuring at least the email is the same.