### PR TITLE
Update tests to use Cypress aliases

### DIFF
--- a/cypress/integration/events.js
+++ b/cypress/integration/events.js
@@ -1,138 +1,147 @@
-describe('Event sign up', () => {
-  let email
-  let firstName
-  let lastName
-  const eventSelector = '.events-featured__list__item'
+describe("Event sign up", () => {
+  const eventSelector = ".events-featured__list__item";
 
   beforeEach(() => {
-    checkEventSelectorIsCorrect()
-    navigateToLastPageOfEvents()
-    cy.random().then((rand) => {
-      firstName = `First-${rand}`
-      lastName = `Last-${rand}`
-    })
-  })
+    checkEventSelectorIsCorrect();
+    navigateToLastPageOfEvents();
 
-  describe('As a new candidate', () => {
-    before(() => {
-      cy.random().then((rand) => {
-        email = `${rand}@${rand}.never`
-      })
-    })
+    cy.random()
+      .then((rand) => `First-${rand}`)
+      .as("firstName")
+      .then((rand) => `Last-${rand}`)
+      .as("lastName");
+  });
 
-    it('Signing up (without mailing list)', () => {    
+  describe("As a new candidate", () => {
+    beforeEach(() => {
+      cy.random()
+        .then((rand) => `${rand}@${rand}.never`)
+        .as("email");
+    });
+
+    it("Signing up (without mailing list)", function () {
       cy.anEventExists().then((exists) => {
         if (exists) {
-          navigateToLastEventSignUp()
-          signUp(firstName, lastName, false)
+          navigateToLastEventSignUp();
+          signUp(this.firstName, this.lastName, this.email, false);
         }
-      })
+      });
+    });
 
-      it('Signing up (with mailing list)', () => {    
-        cy.anEventExists().then((exists) => {
-          if (exists) {
-            navigateToLastEventSignUp()
-            signUp(firstName, lastName, true)
-          }
-        })
-      })
-    })
-  })
-
-  describe('As an existing candidate', () => {
-    before(() => {
-      cy.fixture('test_data.json').then((testData) => {
-        email = testData.events.email
-      })
-    })
-
-    it('Signing up (with mailing list, resends verification code)', () => {    
+    it("Signing up (with mailing list)", function () {
       cy.anEventExists().then((exists) => {
         if (exists) {
-          navigateToLastEventSignUp()
-
-          submitPersonalDetails(firstName, lastName)
-
-          cy.clickWithText('resend verification')
-          cy.contains('We\'ve sent you another email.')
-
-          cy.waitForJobs()
-
-          cy.retrieveVerificationCode(email).then((code) => {
-            cy.getByLabel(`Check your email and enter the verification code sent to ${email}`).type(code)
-            cy.clickNext()
-
-            cy.contains('Are you over 16 and do you agree to our privacy policy?')
-            cy.get('.govuk-checkboxes').contains('Yes').click()
-
-            cy.clickCompleteSignUp()
-          })
+          navigateToLastEventSignUp();
+          signUp(this.firstName, this.lastName, this.email, true);
         }
-      })
-    })
-  })
+      });
+    });
+  });
 
-  const signUp = (firstName, lastName, mailingList) => {
-    submitPersonalDetails(firstName, lastName)
+  describe("As an existing candidate", () => {
+    before(() => {
+      cy.fixture("test_data.json")
+        .then((testData) => testData.events.email)
+        .as("email");
+    });
 
-    cy.getByLabel('Phone number (optional)').type('123456789')
-    cy.clickNext()
+    it("Signing up (with mailing list, resends verification code)", function () {
+      cy.anEventExists().then((exists) => {
+        if (exists) {
+          navigateToLastEventSignUp();
 
-    cy.contains('Are you over 16 and do you agree to our privacy policy?')
-    cy.get('.govuk-checkboxes').contains('Yes').click()
+          submitPersonalDetails(this.firstName, this.lastName, this.email);
 
-    cy.contains('Would you like to receive email updates to help you get into teaching?')
-    cy.get('.govuk-radios__item').contains(mailingList ? 'Yes' : 'No').click()
+          cy.clickWithText("resend verification");
+          cy.contains("We've sent you another email.");
+
+          cy.waitForJobs();
+
+          cy.retrieveVerificationCode(this.email).then((code) => {
+            cy.getByLabel(
+              `Check your email and enter the verification code sent to ${this.email}`
+            ).type(code);
+            cy.clickNext();
+
+            cy.contains(
+              "Are you over 16 and do you agree to our privacy policy?"
+            );
+            cy.get(".govuk-checkboxes").contains("Yes").click();
+
+            cy.clickCompleteSignUp();
+          });
+        }
+      });
+    });
+  });
+
+  const signUp = (firstName, lastName, email, mailingList) => {
+    submitPersonalDetails(firstName, lastName, email);
+
+    cy.getByLabel("Phone number (optional)").type("123456789");
+    cy.clickNext();
+
+    cy.contains("Are you over 16 and do you agree to our privacy policy?");
+    cy.get(".govuk-checkboxes").contains("Yes").click();
+
+    cy.contains(
+      "Would you like to receive email updates to help you get into teaching?"
+    );
+    cy.get(".govuk-radios__item")
+      .contains(mailingList ? "Yes" : "No")
+      .click();
 
     if (mailingList) {
-      cy.get('.govuk-radios__item').contains('Yes').click()
-      cy.clickNext()
-      completeMailingListSignUp()
+      cy.get(".govuk-radios__item").contains("Yes").click();
+      cy.clickNext();
+      completeMailingListSignUp();
     } else {
-      cy.get('.govuk-radios__item').contains('No').click()
+      cy.get(".govuk-radios__item").contains("No").click();
     }
 
-    cy.clickCompleteSignUp()
+    cy.clickCompleteSignUp();
 
-    cy.contains('Sign up complete')
-  }
+    cy.contains("Sign up complete");
+  };
 
   const completeMailingListSignUp = () => {
-    cy.getByLabel('Do you have a degree?').select('Final year')
-    cy.getByLabel('How close are you to applying for teacher training?').select('It’s just an idea')
-    cy.getByLabel('What is your postcode? (optional)').type('TE5 1NG')
-    cy.getByLabel('What subject do you want to teach?').select('Maths')
-  }
+    cy.getByLabel("Do you have a degree?").select("Final year");
+    cy.getByLabel("How close are you to applying for teacher training?").select(
+      "It’s just an idea"
+    );
+    cy.getByLabel("What is your postcode? (optional)").type("TE5 1NG");
+    cy.getByLabel("What subject do you want to teach?").select("Maths");
+  };
 
-  const submitPersonalDetails = (firstName, lastName) => {
-    cy.contains('Sign up for this event')
-    cy.getByLabel('First name').type(firstName)
-    cy.getByLabel('Last name').type(lastName)
-    cy.getByLabel('Email address').type(email)
-    cy.clickNext()
-  }
+  const submitPersonalDetails = (firstName, lastName, email) => {
+    cy.contains("Sign up for this event");
+    cy.getByLabel("First name").type(firstName);
+    cy.getByLabel("Last name").type(lastName);
+    cy.getByLabel("Email address").type(email);
+    cy.clickNext();
+  };
 
   const navigateToLastPageOfEvents = () => {
-    cy.authVisit('/event-categories/train-to-teach-events')
+    cy.authVisit("/event-categories/train-to-teach-events");
 
-    cy.get('body').then((body) => {
-      if (body.find('.pagination').length) {
-        cy.get('.pagination .page a').last().click()
+    cy.get("body").then((body) => {
+      if (body.find(".pagination").length) {
+        cy.get(".pagination .page a").last().click();
       }
-    })
-  }
+    });
+  };
 
   const navigateToLastEventSignUp = () => {
-    cy.get(eventSelector).last().click()
-    cy.clickWithText('Sign up for this event')
-  }
+    cy.get(eventSelector).last().click();
+    cy.clickWithText("Sign up for this event");
+  };
 
   // The tests are setup to pass when there are no TTT
-  // events. To avoid a false positive we need to verify 
+  // events. To avoid a false positive we need to verify
   // the event selector hasn't changed before each run.
   const checkEventSelectorIsCorrect = () => {
-    cy.authVisit('/events')
-    cy.acceptCookie()
-    cy.get(eventSelector)
-  }
-})
+    cy.authVisit("/events");
+    cy.acceptCookie();
+    cy.get(eventSelector);
+  };
+});

--- a/cypress/integration/get_an_adviser.js
+++ b/cypress/integration/get_an_adviser.js
@@ -1,108 +1,114 @@
-describe('Mailing list sign up', () => {
-  let email
-  let firstName
-  let lastName
-
+describe("Mailing list sign up", () => {
   beforeEach(() => {
-    cy.authVisit(Cypress.env('TTA_ROOT_URL'))
-    cy.acceptCookie()
-    cy.clickWithText('Start now')
-    cy.random().then((rand) => {
-      firstName = `First-${rand}`
-      lastName = `Last-${rand}`
-    })
-  })
+    cy.authVisit(Cypress.env("TTA_ROOT_URL"));
+    cy.acceptCookie();
+    cy.clickWithText("Start now");
 
-  describe('As a new candidate', () => {
+    cy.random()
+      .then((rand) => `First-${rand}`)
+      .as("firstName")
+      .then((rand) => `Last-${rand}`)
+      .as("lastName");
+  });
+
+  describe("As a new candidate", () => {
     before(() => {
-      cy.random().then((rand) => {
-        email = `${rand}@${rand}.never`
-      })
-    })
+      cy.random()
+        .then((rand) => `${rand}@${rand}.never`)
+        .as("email");
+    });
 
-    it('Signing up', () => {    
-      signUp(firstName, lastName)
-    })
-  })
+    it("Signing up", function () {
+      signUp(this.firstName, this.lastName, this.email);
+    });
+  });
 
-  describe('As an existing candidate', () => {
+  describe("As an existing candidate", () => {
     before(() => {
-      cy.fixture('test_data.json').then((testData) => {
-        email = testData.getAnAdviser.email
-      })
-    })
+      cy.fixture("test_data.json")
+        .then((testData) => testData.getAnAdviser.email)
+        .as("email");
+    });
 
-    it('Signing up (resends verification code)', () => {    
-      submitPersonalDetails(firstName, lastName)
+    it("Signing up (resends verification code)", function () {
+      submitPersonalDetails(this.firstName, this.lastName, this.email);
 
-      cy.clickWithText('resend verification')
-      cy.contains('We\'ve sent you another email.')
+      cy.clickWithText("resend verification");
+      cy.contains("We've sent you another email.");
 
-      cy.waitForJobs()
+      cy.waitForJobs();
 
-      cy.retrieveVerificationCode(email).then((code) => {
-        cy.contains('Verify your email address')
-        cy.getByLabel(`Check your email and enter the verification code sent to ${email}`).type(code)
-        cy.clickContinue()
+      cy.retrieveVerificationCode(this.email).then((code) => {
+        cy.contains("Verify your email address");
+        cy.getByLabel(
+          `Check your email and enter the verification code sent to ${this.email}`
+        ).type(code);
+        cy.clickContinue();
 
-        cy.contains('You have already signed up to this service')
-      })
-    })
-  })
+        cy.contains("You have already signed up to this service");
+      });
+    });
+  });
 
-  const signUp = (firstName, lastName) => {
-    submitPersonalDetails(firstName, lastName)
+  const signUp = (firstName, lastName, email) => {
+    submitPersonalDetails(firstName, lastName, email);
 
-    cy.contains('Are you qualified to teach in the UK?')
-    cy.clickWithText('No')
-    cy.clickContinue()
+    cy.contains("Are you qualified to teach in the UK?");
+    cy.clickWithText("No");
+    cy.clickContinue();
 
-    cy.contains('Do you have a degree?')
-    cy.clickWithText('I have, or I\'m studying for, an equivalent qualification from another country')
-    cy.clickContinue()
+    cy.contains("Do you have a degree?");
+    cy.clickWithText(
+      "I have, or I'm studying for, an equivalent qualification from another country"
+    );
+    cy.clickContinue();
 
-    cy.contains('Which stage are you interested in teaching?')
-    cy.clickWithText('Primary')
-    cy.clickContinue()
+    cy.contains("Which stage are you interested in teaching?");
+    cy.clickWithText("Primary");
+    cy.clickContinue();
 
-    cy.getByLabel('When do you want to start your teacher training?').select('Not sure')
-    cy.clickContinue()
+    cy.getByLabel("When do you want to start your teacher training?").select(
+      "Not sure"
+    );
+    cy.clickContinue();
 
-    cy.contains('Enter your date of birth')
-    cy.getByLabel('Day').type(23)
-    cy.getByLabel('Month').type(3)
-    cy.getByLabel('Year').type(1986)
-    cy.clickContinue()
+    cy.contains("Enter your date of birth");
+    cy.getByLabel("Day").type(23);
+    cy.getByLabel("Month").type(3);
+    cy.getByLabel("Year").type(1986);
+    cy.clickContinue();
 
-    cy.contains('Where do you live?')
-    cy.getByLabel('UK').click()
-    cy.clickContinue()
+    cy.contains("Where do you live?");
+    cy.getByLabel("UK").click();
+    cy.clickContinue();
 
-    cy.contains('What is your address?')
-    cy.getByLabel('Address line 1').type('7 Main Street')
-    cy.getByLabel('Town or City').type('Town')
-    cy.getByLabel('Postcode').type('TE7 1NG')
-    cy.clickContinue()
+    cy.contains("What is your address?");
+    cy.getByLabel("Address line 1").type("7 Main Street");
+    cy.getByLabel("Town or City").type("Town");
+    cy.getByLabel("Postcode").type("TE7 1NG");
+    cy.clickContinue();
 
-    cy.contains('You told us you have an equivalent degree and live in the United Kingdom')
-    cy.getByLabel('Contact telephone number').type('1234567890')
-    cy.clickContinue()
+    cy.contains(
+      "You told us you have an equivalent degree and live in the United Kingdom"
+    );
+    cy.getByLabel("Contact telephone number").type("1234567890");
+    cy.clickContinue();
 
-    cy.contains('Check your answers before you continue')
-    cy.clickContinue()
+    cy.contains("Check your answers before you continue");
+    cy.clickContinue();
 
-    cy.contains('Read and accept the privacy policy')
-    cy.clickWithText('Accept the privacy policy')
-    cy.clickComplete()
+    cy.contains("Read and accept the privacy policy");
+    cy.clickWithText("Accept the privacy policy");
+    cy.clickComplete();
 
-    cy.contains('Sign up complete')
-  }
+    cy.contains("Sign up complete");
+  };
 
-  const submitPersonalDetails = (firstName, lastName) => {
-    cy.contains('About you')
-    cy.getByLabel('First name').type(firstName)
-    cy.getByLabel('Last name').type(lastName)
-    cy.getByLabel('Email address').type(email)
-    cy.clickContinue()
-  }
-})
+  const submitPersonalDetails = (firstName, lastName, email) => {
+    cy.contains("About you");
+    cy.getByLabel("First name").type(firstName);
+    cy.getByLabel("Last name").type(lastName);
+    cy.getByLabel("Email address").type(email);
+    cy.clickContinue();
+  };
+});

--- a/cypress/integration/mailing_list.js
+++ b/cypress/integration/mailing_list.js
@@ -1,121 +1,120 @@
-describe('Mailing list sign up', () => {
-  let email
-  let firstName
-  let lastName
-
+describe("Mailing list sign up", () => {
   beforeEach(() => {
-    cy.authVisit('/mailinglist/signup')
-    cy.acceptCookie()
+    cy.authVisit("/mailinglist/signup");
+    cy.acceptCookie();
 
-    cy.random().then((rand) => {
-      firstName = `First-${rand}`
-      lastName = `Last-${rand}`
-    })
-  })
+    cy.random()
+      .then((rand) => `First-${rand}`)
+      .as("firstName")
+      .then((rand) => `Last-${rand}`)
+      .as("lastName");
+  });
 
-  describe('As a new candidate', () => {
+  describe("As a new candidate", () => {
     before(() => {
-      cy.random().then((rand) => {
-        email = `${rand}@${rand}.never`
-      })
-    })
+      cy.random()
+        .then((rand) => `${rand}@${rand}.never`)
+        .as("email");
+    });
 
-    it('Signing up', () => {
-      signUp(firstName, lastName)
-    })
-  })
+    it("Signing up", function () {
+      signUp(this.firstName, this.lastName, this.email);
+    });
+  });
 
-  describe('As an existing candidate', () => {
+  describe("As an existing candidate", () => {
     before(() => {
-      cy.fixture('test_data.json').then((testData) => {
-        email = testData.mailingList.email
-      })
-    })
+      cy.fixture("test_data.json")
+        .then((testData) => testData.mailingList.email)
+        .as("email");
+    });
 
-    it('Signing up (resends verification code)', () => {  
-      cy.contains('Get personalised guidance to your inbox')
-      submitPersonalDetails(firstName, lastName)
-  
-      cy.clickWithText('resend verification')
-      cy.contains("We've sent you another email.")
-  
-      cy.waitForJobs()
-  
-      cy.retrieveVerificationCode(email).then((code) => {
-        cy.contains('Verify your email address')
+    it("Signing up (resends verification code)", function () {
+      cy.contains("Get personalised guidance to your inbox");
+      submitPersonalDetails(this.firstName, this.lastName, this.email);
+
+      cy.clickWithText("resend verification");
+      cy.contains("We've sent you another email.");
+
+      cy.waitForJobs();
+
+      cy.retrieveVerificationCode(this.email).then((code) => {
+        cy.contains("Verify your email address");
         cy.getByLabel(
-          `Check your email and enter the verification code sent to ${email}`
-        ).type(code)
-        cy.clickNext()
-  
-        cy.contains('You’ve already signed up')
-      })
-    })
+          `Check your email and enter the verification code sent to ${this.email}`
+        ).type(code);
+        cy.clickNext();
 
-    it('Booking a callback on completion of the mailing list sign up', () => {
-      cy.authVisit('/mailinglist/signup/completed')
-  
-      cy.contains('Book a callback').click()
-  
-      submitPersonalDetails(firstName, lastName)
-      cy.clickNext()
-  
-      cy.clickWithText('resend verification')
-      cy.contains("We've sent you another email.")
-  
-      cy.waitForJobs()
-  
-      cy.retrieveVerificationCode(email).then((code) => {
-        cy.contains('Verify your email address')
+        cy.contains("You’ve already signed up");
+      });
+    });
+
+    it("Booking a callback on completion of the mailing list sign up", function () {
+      cy.authVisit("/mailinglist/signup/completed");
+
+      cy.contains("Book a callback").click();
+
+      submitPersonalDetails(this.firstName, this.lastName, this.email);
+      cy.clickNext();
+
+      cy.clickWithText("resend verification");
+      cy.contains("We've sent you another email.");
+
+      cy.waitForJobs();
+
+      cy.retrieveVerificationCode(this.email).then((code) => {
+        cy.contains("Verify your email address");
         cy.getByLabel(
-          `Check your email and enter the verification code sent to ${email}`
-        ).type(code)
-        cy.clickNext()
-      })
-  
-      cy.getByLabel('Phone number').clear().type('1234567890')
-      cy.clickNext()
-  
-      cy.getByLabel('Choose an option').select('Eligibility to become a teacher')
-      cy.clickNext()
-  
-      cy.contains('Accept privacy policy')
-      cy.clickWithText('Yes')
-  
-      cy.clickWithText('Book your callback')
-      cy.contains('Callback confirmed')
-    })
-  })
+          `Check your email and enter the verification code sent to ${this.email}`
+        ).type(code);
+        cy.clickNext();
+      });
 
-  const signUp = (firstName, lastName) => {
-    cy.contains('Get personalised guidance to your inbox')
-    submitPersonalDetails(firstName, lastName)
+      cy.getByLabel("Phone number").clear().type("1234567890");
+      cy.clickNext();
 
-    cy.contains('Do you have a degree?')
-    cy.clickWithText('Yes, I already have a degree')
-    cy.clickNext()
+      cy.getByLabel("Choose an option").select(
+        "Eligibility to become a teacher"
+      );
+      cy.clickNext();
 
-    cy.contains('How close are you to applying for teacher training?')
-    cy.clickWithText('I’m not sure and finding out more')
-    cy.clickNext()
+      cy.contains("Accept privacy policy");
+      cy.clickWithText("Yes");
 
-    cy.getByLabel('Which subject do you want to teach?').select('Chemistry')
-    cy.clickNext()
+      cy.clickWithText("Book your callback");
+      cy.contains("Callback confirmed");
+    });
+  });
 
-    cy.getByLabel('Your postcode (optional)').type('TE5 1NG')
-    cy.clickNext()
+  const signUp = (firstName, lastName, email) => {
+    cy.contains("Get personalised guidance to your inbox");
+    submitPersonalDetails(firstName, lastName, email);
 
-    cy.contains('Accept privacy policy')
-    cy.clickWithText('Yes')
-    cy.clickCompleteSignUp()
+    cy.contains("Do you have a degree?");
+    cy.clickWithText("Yes, I already have a degree");
+    cy.clickNext();
 
-    cy.contains("You've signed up")
-  }
+    cy.contains("How close are you to applying for teacher training?");
+    cy.clickWithText("I’m not sure and finding out more");
+    cy.clickNext();
 
-  const submitPersonalDetails = (firstName, lastName) => {
-    cy.getByLabel('First name').type(firstName)
-    cy.getByLabel('Last name').type(lastName)
-    cy.getByLabel('Email address').type(email)
-    cy.clickNext()
-  }
-})
+    cy.getByLabel("Which subject do you want to teach?").select("Chemistry");
+    cy.clickNext();
+
+    cy.getByLabel("Your postcode (optional)").type("TE5 1NG");
+    cy.clickNext();
+
+    cy.contains("Accept privacy policy");
+    cy.clickWithText("Yes");
+    cy.clickCompleteSignUp();
+
+    cy.contains("You've signed up");
+  };
+
+  const submitPersonalDetails = (firstName, lastName, email) => {
+    cy.getByLabel("First name").type(firstName);
+    cy.getByLabel("Last name").type(lastName);
+    cy.getByLabel("Email address").type(email);
+    cy.clickNext();
+  };
+});


### PR DESCRIPTION
Cypress recommend that we use Aliases instead of declaring variables at the describe level.

One of the events tests 'Signing up (without mailing list)' was also nested awkwardly so wasn't running.