### PR TITLE
Update tests to reflect recent changes

### DIFF
--- a/cypress/integration/events.js
+++ b/cypress/integration/events.js
@@ -78,7 +78,7 @@ describe("Event sign up", () => {
   const signUp = (firstName, lastName, email, mailingList) => {
     submitPersonalDetails(firstName, lastName, email);
 
-    cy.getByLabel("Phone number (optional)").type("123456789");
+    cy.getByLabel("What is your telephone number? (optional)").type("123456789");
     cy.clickNext();
 
     cy.contains("Are you over 16 and do you agree to our privacy policy?");

--- a/cypress/integration/mailing_list.js
+++ b/cypress/integration/mailing_list.js
@@ -50,9 +50,7 @@ describe("Mailing list sign up", () => {
     });
 
     it("Booking a callback on completion of the mailing list sign up", function () {
-      cy.authVisit("/mailinglist/signup/completed");
-
-      cy.contains("Book a callback").click();
+      cy.authVisit("/callbacks/book");
 
       submitPersonalDetails(this.firstName, this.lastName, this.email);
       cy.clickNext();
@@ -108,7 +106,7 @@ describe("Mailing list sign up", () => {
     cy.clickWithText("Yes");
     cy.clickCompleteSignUp();
 
-    cy.contains("You've signed up");
+    cy.contains("you're signed up");
   };
 
   const submitPersonalDetails = (firstName, lastName, email) => {


### PR DESCRIPTION
There have been a couple of minor copy changes to the mailing list and event sign up flows.

It also looks like the 'book a callback' button is now missing in the preprod environment; I'm not sure if thats intentional with
the new welcome guide journey updates or not, but to get the pipeline unblocked we can visit the book a callback wizard
directly.

Old ML completion page (still in prod):
<img width="400" alt="Screenshot 2021-11-11 at 12 05 09" src="https://user-images.githubusercontent.com/29867726/141295124-7265b83d-d2e0-4e25-9cf8-8d6a48cc2a7e.png">

New ML completion page (in dev/test):
<img width="400" alt="Screenshot 2021-11-11 at 12 04 53" src="https://user-images.githubusercontent.com/29867726/141295102-8ff2071e-8790-4f42-a3d4-ba70be34d7b3.png">


