### PR TITLE
Update tests to work with Turbo

### DIFF
--- a/cypress/integration/events.js
+++ b/cypress/integration/events.js
@@ -112,7 +112,7 @@ describe("Event sign up", () => {
   };
 
   const submitPersonalDetails = (firstName, lastName, email) => {
-    cy.contains("Sign up for this event");
+    cy.contains("First name");
     cy.getByLabel("First name").type(firstName);
     cy.getByLabel("Last name").type(lastName);
     cy.getByLabel("Email address").type(email);
@@ -130,6 +130,9 @@ describe("Event sign up", () => {
   };
 
   const navigateToLastEventSignUp = () => {
+    // Short wait to ensure the last page has loaded otherwise
+    // Cypress seems to get ahead of Turbo occasionally.
+    cy.wait(1000)
     cy.get(eventSelector).last().click();
     cy.clickWithText("Sign up for this event");
   };

--- a/cypress/integration/mailing_list.js
+++ b/cypress/integration/mailing_list.js
@@ -51,7 +51,6 @@ describe("Mailing list sign up", () => {
       cy.authVisit("/callbacks/book");
 
       submitPersonalDetails(this.firstName, this.lastName, this.email);
-      cy.clickNext();
 
       cy.clickWithText("Send another code to verify my details.");
       cy.contains("We've sent you another email");


### PR DESCRIPTION
As Turbo picks up more page changes than Turbolinks the Cypress tests appear to get ahead of it on occasion. Add a wait to avoid flakiness around the last event selection and remove redundant `clickNext()` on the mailing list sign up.