### PR TITLE
Add short wait to fix flakey spec

### DIFF
--- a/cypress/integration/events.js
+++ b/cypress/integration/events.js
@@ -112,7 +112,9 @@ describe("Event sign up", () => {
   };
 
   const submitPersonalDetails = (firstName, lastName, email) => {
-    cy.contains("First name");
+    // Short wait to ensure the last page has loaded otherwise
+    // Cypress seems to get ahead of Turbo occasionally.
+    cy.wait(1000)
     cy.getByLabel("First name").type(firstName);
     cy.getByLabel("Last name").type(lastName);
     cy.getByLabel("Email address").type(email);


### PR DESCRIPTION
Cypress is getting ahead of Turbo; I need to figure out what exactly is
going on but just aiming to patch it for now to open the pipeline back up.